### PR TITLE
runtimeInputs -> Packages

### DIFF
--- a/Changelog.org
+++ b/Changelog.org
@@ -1,0 +1,4 @@
+* Unreleased
+
+* Version 0.3.0.0
+- Consistently use the word /package/ across languages: =runtimeInputs= -> =packages= .

--- a/Readme.org
+++ b/Readme.org
@@ -15,7 +15,7 @@ package manager]].
 #+begin_src sh :exports code
 #!/usr/bin/env magix
 #!magix bash
-#!runtimeInputs jq
+#!packages jq
 
 jq --help
 #+end_src

--- a/magix.cabal
+++ b/magix.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.4
 name:               magix
-version:            0.2.0.0
+version:            0.3.0.0
 synopsis:
   Build, cache, and run possibly compiled scripts with dependencies using the Nix package manager
 

--- a/src/Magix/Languages/Bash/Directives.hs
+++ b/src/Magix/Languages/Bash/Directives.hs
@@ -19,11 +19,11 @@ import Data.Text (Text)
 import Magix.Directives.Common (Parser, pDirectiveWithValues, pLanguageDirectives)
 import Prelude hiding (readFile)
 
-newtype BashDirectives = BashDirectives {_runtimeInputs :: [Text]}
+newtype BashDirectives = BashDirectives {_packages :: [Text]}
   deriving (Eq, Show, Semigroup, Monoid)
 
-pRuntimeInputs :: Parser BashDirectives
-pRuntimeInputs = BashDirectives <$> pDirectiveWithValues "runtimeInputs"
+pPackages :: Parser BashDirectives
+pPackages = BashDirectives <$> pDirectiveWithValues "packages"
 
 pBashDirectives :: Parser BashDirectives
-pBashDirectives = pLanguageDirectives "bash" pRuntimeInputs mconcat
+pBashDirectives = pLanguageDirectives "bash" pPackages mconcat

--- a/src/Magix/Languages/Bash/Expression.hs
+++ b/src/Magix/Languages/Bash/Expression.hs
@@ -19,4 +19,4 @@ import Magix.Languages.Bash.Directives (BashDirectives (..))
 import Prelude hiding (unwords)
 
 getBashReplacements :: BashDirectives -> [(Text, Text)]
-getBashReplacements (BashDirectives ps) = [("__RUNTIME_INPUTS__", unwords ps)]
+getBashReplacements (BashDirectives ps) = [("__PACKAGES__", unwords ps)]

--- a/src/Magix/Languages/Bash/Template.nix
+++ b/src/Magix/Languages/Bash/Template.nix
@@ -5,7 +5,7 @@
 pkgs.writeShellApplication {
   name = "__SCRIPT_NAME__";
 
-  runtimeInputs = with pkgs; [ __RUNTIME_INPUTS__ ];
+  runtimeInputs = with pkgs; [ __PACKAGES__ ];
 
   text = ''
     BASH_ARGV0="__SCRIPT_NAME__"

--- a/test-scripts/bash/minimal
+++ b/test-scripts/bash/minimal
@@ -1,5 +1,5 @@
 #!/usr/bin/env magix
 #!magix bash
-#!runtimeInputs jq
+#!packages jq
 
 jq --help

--- a/test/Magix/DirectivesSpec.hs
+++ b/test/Magix/DirectivesSpec.hs
@@ -42,7 +42,7 @@ spaceTest =
   unlines
     [ "#!/usr/bin/env magix",
       "#!magix bash",
-      "#!runtimeInputs a ",
+      "#!packages a ",
       ""
     ]
 
@@ -51,7 +51,7 @@ newlineTest =
   unlines
     [ "#!/usr/bin/env magix",
       "#!magix bash",
-      "#!runtimeInputs a",
+      "#!packages a",
       ""
     ]
 

--- a/test/Magix/Languages/Bash/DirectivesSpec.hs
+++ b/test/Magix/Languages/Bash/DirectivesSpec.hs
@@ -27,16 +27,16 @@ minimal :: Text
 minimal =
   unlines
     [ "#!magix bash",
-      "#!runtimeInputs jq"
+      "#!packages jq"
     ]
 
 multiple :: Text
 multiple =
   unlines
     [ "#!magix bash",
-      "#!runtimeInputs a",
-      "#!runtimeInputs b c",
-      "#!runtimeInputs d e f"
+      "#!packages a",
+      "#!packages b c",
+      "#!packages d e f"
     ]
 
 spec :: Spec

--- a/test/Magix/Languages/Bash/ExpressionSpec.hs
+++ b/test/Magix/Languages/Bash/ExpressionSpec.hs
@@ -20,11 +20,11 @@ import Magix.Languages.Bash.Directives (BashDirectives (..))
 import Magix.Tools (testExpression)
 import Test.Hspec (Spec)
 
-runtimeInputs :: [Text]
-runtimeInputs = ["fake", "inputs"]
+packages :: [Text]
+packages = ["fake", "inputs"]
 
 bashDirectives :: Directives
-bashDirectives = Bash $ BashDirectives runtimeInputs
+bashDirectives = Bash $ BashDirectives packages
 
 spec :: Spec
-spec = testExpression bashDirectives [runtimeInputs]
+spec = testExpression bashDirectives [packages]


### PR DESCRIPTION
Consistently use the word /package/ across languages: =runtimeInputs= -> =packages= .