### PR TITLE
Resolve nixpkgs from unprefixed NIX_PATH directories

### DIFF
--- a/Changelog.org
+++ b/Changelog.org
@@ -1,4 +1,6 @@
 * Unreleased
+- Resolve =nixpkgs= from unprefixed directories in =$NIX_PATH= (like
+  =builtins.findFile=); fixes https://github.com/dschrempf/magix/issues/18
 
 * Version 1.0.0.0
 ** User-facing

--- a/magix.cabal
+++ b/magix.cabal
@@ -14,7 +14,7 @@ author:             Dominik Schrempf
 maintainer:         dominik.schrempf@gmail.com
 copyright:          2024 Dominik Schrempf
 license:            GPL-3.0-or-later
-license-file:       License.txt
+license-file:       LICENSE
 build-type:         Simple
 extra-doc-files:
   Changelog.org

--- a/src/Magix/Config.hs
+++ b/src/Magix/Config.hs
@@ -26,7 +26,7 @@ import Data.Text (Text)
 import Magix.BuildMode (BuildMode (..))
 import Magix.Env (NixEnv (..), nixEnvDesc)
 import Magix.Hash (MagixHashContents (..), getMagixHash)
-import Magix.NixpkgsPath (getDefaultNixpkgsPath)
+import Magix.NixpkgsPath (getDefaultNixpkgsPath, resolveNixpkgs)
 import Magix.Options (Options (..))
 import Magix.Paths (getBuildDir, getLockPath, getResultLinkPath)
 import System.Directory (canonicalizePath)
@@ -60,7 +60,12 @@ getDefaultNixpkgsPathOrFail (Just np) = case getDefaultNixpkgsPath np of
   Left err -> do
     putStrLn $ "Could not retrieve Nixpkgs path from " <> fst nixEnvDesc.nixPath
     throwIO err
-  Right p -> pure p
+  Right entries -> resolveFirst entries
+  where
+    -- Return the first entry resolving to a Nixpkgs path.
+    resolveFirst [] =
+      die $ "Could not find Nixpkgs in " <> fst nixEnvDesc.nixPath <> ": " <> np
+    resolveFirst (e : es) = resolveNixpkgs e >>= maybe (resolveFirst es) pure
 
 -- | Resolve the build mode.
 -- Priority: script's #!nixpkgs directive > CLI/env > NIX_PATH channel

--- a/src/Magix/NixpkgsPath.hs
+++ b/src/Magix/NixpkgsPath.hs
@@ -10,28 +10,63 @@
 --
 -- Creation date: Thu Oct 24 06:47:24 2024.
 module Magix.NixpkgsPath
-  ( pNixpkgsPath,
+  ( NixPathEntry (..),
+    pNixPathEntry,
     pNixPath,
     getDefaultNixpkgsPath,
+    resolveNixpkgs,
   )
 where
 
+import Control.Applicative (optional)
 import Control.Exception (Exception)
-import Data.Bifunctor (Bifunctor (..))
+import Control.Monad (void)
+import Data.Bifunctor (Bifunctor (first))
 import Data.Char (isSpace)
 import Data.Void (Void)
-import Text.Megaparsec (MonadParsec (takeWhile1P), Parsec, anySingle, chunk, errorBundlePretty, parse, (<|>))
+import System.Directory (doesPathExist)
+import System.FilePath ((</>))
+import Text.Megaparsec
+  ( MonadParsec (takeWhile1P),
+    Parsec,
+    eof,
+    errorBundlePretty,
+    parse,
+    sepEndBy,
+  )
 
 type Parser = Parsec Void String
 
-isValidPathChar :: Char -> Bool
-isValidPathChar x = x /= ':' && not (isSpace x)
+-- | A single entry of @NIX_PATH@.
+--
+-- Entries are either prefixed (@prefix=path@, e.g. @nixpkgs=/path@) or
+-- unprefixed directories. For an unprefixed directory @dir@, a lookup @<x>@
+-- resolves to @dir/x@ (see @builtins.findFile@).
+data NixPathEntry
+  = Prefixed !String !FilePath
+  | Unprefixed !FilePath
+  deriving (Eq, Show)
 
-pNixpkgsPath :: Parser FilePath
-pNixpkgsPath = chunk "nixpkgs=" *> takeWhile1P (Just "pathComponents") isValidPathChar
+-- | Characters allowed inside a @NIX_PATH@ entry (colon and whitespace separate
+-- entries).
+isEntryChar :: Char -> Bool
+isEntryChar x = x /= ':' && not (isSpace x)
 
-pNixPath :: Parser FilePath
-pNixPath = pNixpkgsPath <|> (anySingle *> pNixPath)
+-- | Separator between @NIX_PATH@ entries.
+pSep :: Parser ()
+pSep = void $ takeWhile1P (Just "separator") (\x -> x == ':' || isSpace x)
+
+-- | Parse a single @NIX_PATH@ entry and classify it as prefixed or unprefixed.
+pNixPathEntry :: Parser NixPathEntry
+pNixPathEntry = classify <$> takeWhile1P (Just "entry") isEntryChar
+  where
+    classify tok = case break (== '=') tok of
+      (prefix, '=' : path) -> Prefixed prefix path
+      _ -> Unprefixed tok
+
+-- | Parse the value of @NIX_PATH@ into its entries.
+pNixPath :: Parser [NixPathEntry]
+pNixPath = optional pSep *> sepEndBy pNixPathEntry pSep <* eof
 
 data NixpkgsPathError = NixpkgsPathError
   { _nixPath :: !String,
@@ -41,8 +76,20 @@ data NixpkgsPathError = NixpkgsPathError
 
 instance Exception NixpkgsPathError
 
--- | Parse the Nixpkgs path from the value of @NIX_PATH@.
-getDefaultNixpkgsPath :: String -> Either NixpkgsPathError FilePath
-getDefaultNixpkgsPath nixPath = first fromErr $ parse pNixPath "" nixPath
-  where
-    fromErr e = NixpkgsPathError nixPath $ errorBundlePretty e
+-- | Parse the entries of @NIX_PATH@ (see 'resolveNixpkgs' for resolving one to a
+-- Nixpkgs path).
+getDefaultNixpkgsPath :: String -> Either NixpkgsPathError [NixPathEntry]
+getDefaultNixpkgsPath nixPath =
+  first (NixpkgsPathError nixPath . errorBundlePretty) $ parse pNixPath "" nixPath
+
+-- | Resolve a single @NIX_PATH@ entry to a Nixpkgs path, if it provides one.
+--
+-- A @nixpkgs=<path>@ entry resolves to @<path>@. An unprefixed directory @dir@
+-- resolves to @dir/nixpkgs@ if that path exists.
+resolveNixpkgs :: NixPathEntry -> IO (Maybe FilePath)
+resolveNixpkgs (Prefixed "nixpkgs" p) = pure $ Just p
+resolveNixpkgs (Prefixed _ _) = pure Nothing
+resolveNixpkgs (Unprefixed dir) = do
+  let candidate = dir </> "nixpkgs"
+  exists <- doesPathExist candidate
+  pure $ if exists then Just candidate else Nothing

--- a/test/Magix/NixpkgsPathSpec.hs
+++ b/test/Magix/NixpkgsPathSpec.hs
@@ -14,34 +14,82 @@ module Magix.NixpkgsPathSpec
   )
 where
 
-import Magix.NixpkgsPath (getDefaultNixpkgsPath, pNixPath, pNixpkgsPath)
+import Control.Monad (replicateM)
+import Magix.NixpkgsPath (NixPathEntry (..), getDefaultNixpkgsPath, pNixPath, resolveNixpkgs)
 import Magix.Tools (parseS)
+import System.Directory (createDirectory, createDirectoryLink, getTemporaryDirectory)
+import System.FilePath ((</>))
+import System.Random.Stateful (randomRIO)
 import Test.Hspec (Spec, describe, it, shouldBe)
+
+-- | Create a fresh, empty temporary directory.
+getTemporaryTestDir :: IO FilePath
+getTemporaryTestDir = do
+  suffix <- replicateM 20 $ randomRIO ('a', 'z')
+  tmp <- (</> ("magix-nixpath-" <> suffix)) <$> getTemporaryDirectory
+  createDirectory tmp
+  pure tmp
 
 spec :: Spec
 spec = do
-  describe "pNixpkgsPath" $ do
-    let parsesAs = parseS pNixpkgsPath
-    it "parses Nixpkgs path correctly" $ do
-      "nixpkgs=/path/to/nixpkgs" `parsesAs` "/path/to/nixpkgs"
-      "nixpkgs=/path/to/nixpkgs:some=/other/path" `parsesAs` "/path/to/nixpkgs"
-      "nixpkgs=/path/to/nixpkgs some=/other/path" `parsesAs` "/path/to/nixpkgs"
-
   describe "pNixPath" $ do
     let parsesAs = parseS pNixPath
-    it "parses NIX_PATH correctly" $ do
-      "nixpkgs=/path/to/nixpkgs" `parsesAs` "/path/to/nixpkgs"
-      "nixpkgs=/path/to/nixpkgs:some=/other/path" `parsesAs` "/path/to/nixpkgs"
-      "other=/path/here:nixpkgs=/path/to/nixpkgs:some=/other/path"
-        `parsesAs` "/path/to/nixpkgs"
+    it "parses prefixed entries" $ do
+      "nixpkgs=/path/to/nixpkgs" `parsesAs` [Prefixed "nixpkgs" "/path/to/nixpkgs"]
+      "nixpkgs=/path/to/nixpkgs:some=/other/path"
+        `parsesAs` [Prefixed "nixpkgs" "/path/to/nixpkgs", Prefixed "some" "/other/path"]
       "other=/path/here:and=/another:nixpkgs=/path/to/nixpkgs"
-        `parsesAs` "/path/to/nixpkgs"
-      "other=/path/here:and=/another:nixpkgs=/path/to/nixpkgs some=/other/path"
-        `parsesAs` "/path/to/nixpkgs"
-      "nixpkgs=/nix/store/lsy6c2f9alj2gkjj36h754kk63x6701l-source"
-        `parsesAs` "/nix/store/lsy6c2f9alj2gkjj36h754kk63x6701l-source"
+        `parsesAs` [ Prefixed "other" "/path/here",
+                     Prefixed "and" "/another",
+                     Prefixed "nixpkgs" "/path/to/nixpkgs"
+                   ]
+    it "parses unprefixed directories" $ do
+      "/etc/nix/inputs" `parsesAs` [Unprefixed "/etc/nix/inputs"]
+      "/etc/nix/inputs:nixpkgs=/path/to/nixpkgs"
+        `parsesAs` [Unprefixed "/etc/nix/inputs", Prefixed "nixpkgs" "/path/to/nixpkgs"]
+    it "treats whitespace as a separator" $ do
+      "nixpkgs=/path/to/nixpkgs some=/other/path"
+        `parsesAs` [Prefixed "nixpkgs" "/path/to/nixpkgs", Prefixed "some" "/other/path"]
+    it "parses the empty NIX_PATH as no entries" $ do
+      "" `parsesAs` []
+    it "splits an entry at its first '=' (values may contain '=')" $ do
+      "nixpkgs=/a=b=c" `parsesAs` [Prefixed "nixpkgs" "/a=b=c"]
+      "a=b=c:nixpkgs=/x"
+        `parsesAs` [Prefixed "a" "b=c", Prefixed "nixpkgs" "/x"]
+      -- Shared with Nix: an unprefixed path containing '=' is read as prefixed.
+      "/weird=dir" `parsesAs` [Prefixed "/weird" "dir"]
 
-  describe "pDefaultNixpkgsPath" $ do
-    it "works for a sample value" $ do
-      getDefaultNixpkgsPath "nixpkgs=/path/to/nixpkgs"
-        `shouldBe` Right "/path/to/nixpkgs"
+  describe "getDefaultNixpkgsPath" $ do
+    it "parses NIX_PATH into its entries" $ do
+      getDefaultNixpkgsPath "other=/x:nixpkgs=/path/to/nixpkgs"
+        `shouldBe` Right [Prefixed "other" "/x", Prefixed "nixpkgs" "/path/to/nixpkgs"]
+
+  describe "resolveNixpkgs" $ do
+    it "resolves a 'nixpkgs=' entry to its path" $ do
+      res <- resolveNixpkgs (Prefixed "nixpkgs" "/path/to/nixpkgs")
+      res `shouldBe` Just "/path/to/nixpkgs"
+
+    it "resolves a 'nixpkgs=' entry whose value contains '='" $ do
+      res <- resolveNixpkgs (Prefixed "nixpkgs" "/a=b=c")
+      res `shouldBe` Just "/a=b=c"
+
+    it "ignores other prefixed entries" $ do
+      res <- resolveNixpkgs (Prefixed "other" "/path")
+      res `shouldBe` Nothing
+      -- A multi-'=' token like "a=b=c" is a prefixed 'a' entry: skipped, not an error.
+      res' <- resolveNixpkgs (Prefixed "a" "b=c")
+      res' `shouldBe` Nothing
+
+    it "resolves an unprefixed directory containing 'nixpkgs'" $ do
+      dir <- getTemporaryTestDir
+      let target = dir </> "nixpkgs-target"
+          link = dir </> "nixpkgs"
+      createDirectory target
+      createDirectoryLink target link
+      res <- resolveNixpkgs (Unprefixed dir)
+      res `shouldBe` Just link
+
+    it "ignores an unprefixed directory without a 'nixpkgs' entry" $ do
+      dir <- getTemporaryTestDir
+      res <- resolveNixpkgs (Unprefixed dir)
+      res `shouldBe` Nothing


### PR DESCRIPTION
An unprefixed entry `dir` in $NIX_PATH now resolves nixpkgs to `dir/nixpkgs` if it exists, matching builtins.findFile. Fixes #18.